### PR TITLE
chore: Upgrade agent-api core libraries with breaking changes

### DIFF
--- a/cmd/visionanalyzer/main.go
+++ b/cmd/visionanalyzer/main.go
@@ -10,6 +10,7 @@ import (
 
 	"log/slog"
 
+	"github.com/go-logr/logr"
 	"github.com/lmittmann/tint"
 
 	"github.com/bdougie/vision/internal/analyzer"
@@ -20,7 +21,7 @@ func main() {
 	ctx := context.Background()
 
 	// Configure logger
-	logger := slog.New(
+	logger := logr.FromSlogHandler(
 		tint.NewHandler(os.Stderr, &tint.Options{
 			Level:      slog.LevelDebug,
 			TimeFormat: "15:04:05",
@@ -29,7 +30,7 @@ func main() {
 
 	// Parse command line arguments
 	videoPath := "path/to/your/video.mp4"
-	outputDir := "output_frames"  // default value
+	outputDir := "output_frames" // default value
 
 	for i := 1; i < len(os.Args); i++ {
 		switch os.Args[i] {
@@ -59,7 +60,7 @@ func main() {
 	store := storage.NewStorage(outputDir, videoName)
 
 	// Initialize agent
-	visionAgent, err := analyzer.NewAgent(ctx, logger)
+	visionAgent, err := analyzer.NewAgent(ctx, &logger)
 	if err != nil {
 		log.Fatalf("Failed to initialize vision agent: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/bdougie/vision
 go 1.24.0
 
 require (
-	github.com/agent-api/ollama v0.0.0-20250227163112-f9059ce0e517
+	github.com/agent-api/ollama v0.0.0-20250320002643-ac6641ede049
 	github.com/lmittmann/tint v1.0.7
 )
 
-require github.com/agent-api/core v0.0.0-20250227162826-246be7c4b3ff
+require github.com/agent-api/core v0.0.0-20250320002200-9e435dd4d404
+
+require github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
 github.com/agent-api/core v0.0.0-20250227162826-246be7c4b3ff h1:6oife6RpbYLDLkLJw6iXJkGAJsbX4b3cbnkRYx3Ton4=
 github.com/agent-api/core v0.0.0-20250227162826-246be7c4b3ff/go.mod h1:dubJb1P6cSuYOqQvBX/R9inWvHPMDuXCEwqwZfzXWTk=
+github.com/agent-api/core v0.0.0-20250320002200-9e435dd4d404 h1:YcnYeqObLUluLR3FRsFz+DN81zEzqfeWj1B6Dr/O8ds=
+github.com/agent-api/core v0.0.0-20250320002200-9e435dd4d404/go.mod h1:cs19K4yBM1F+VAJfR2mNGsNaQABqpAadgkIqQM0Hc0M=
 github.com/agent-api/ollama v0.0.0-20250227163112-f9059ce0e517 h1:TbVxw+SR//ay95HYTHmdXjWTknAFNQTYlb6QHpsWzVE=
 github.com/agent-api/ollama v0.0.0-20250227163112-f9059ce0e517/go.mod h1:tVh9zEHas5qKT8mbnnG/40xjZbVYqrDy5etlmgOhbvQ=
+github.com/agent-api/ollama v0.0.0-20250320002643-ac6641ede049 h1:XRvuG7dR4pdqZv9HW8VPfUw69CCXFgRGaktr5iNyIBA=
+github.com/agent-api/ollama v0.0.0-20250320002643-ac6641ede049/go.mod h1:tzaL497PaRrGl1x32Aw9jmcRfUmqjWMSjvYn+ivHoaA=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/lmittmann/tint v1.0.7 h1:D/0OqWZ0YOGZ6AyC+5Y2kD8PBEzBk6rFHVSfOqCkF9Y=
 github.com/lmittmann/tint v1.0.7/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=

--- a/internal/analyzer/agent.go
+++ b/internal/analyzer/agent.go
@@ -2,16 +2,17 @@ package analyzer
 
 import (
 	"context"
-	"log/slog"
 	"os/exec"
 
-	"github.com/agent-api/core/pkg/agent"
-	"github.com/agent-api/core/types"
+	"github.com/agent-api/core"
+	"github.com/agent-api/core/agent"
+	"github.com/agent-api/core/agent/bootstrap"
 	"github.com/agent-api/ollama"
+	"github.com/go-logr/logr"
 )
 
 // NewAgent initializes and returns a new vision agent
-func NewAgent(ctx context.Context, logger *slog.Logger) (*agent.DefaultAgent, error) {
+func NewAgent(ctx context.Context, logger *logr.Logger) (*agent.Agent, error) {
 	// Check if Ollama is running
 	_, err := exec.Command("curl", "-s", "http://localhost:11434/api/tags").Output()
 	if err != nil {
@@ -27,18 +28,15 @@ func NewAgent(ctx context.Context, logger *slog.Logger) (*agent.DefaultAgent, er
 	provider := ollama.NewProvider(opts)
 
 	// Use the correct model
-	model := &types.Model{
+	model := &core.Model{
 		ID: "llama3.2-vision:11b",
 	}
 	provider.UseModel(ctx, model)
 
-	// Create agent configuration
-	agentConf := &agent.NewAgentConfig{
-		Provider:     provider,
-		Logger:       logger,
-		SystemPrompt: "You are a visual analysis assistant specialized in detailed image descriptions. If there is a person in the image describe what they are doing in step by step format.",
-	}
-
 	// Initialize agent
-	return agent.NewAgent(agentConf), nil
+	return agent.NewAgent(
+		bootstrap.WithLogger(logger),
+		bootstrap.WithProvider(provider),
+		bootstrap.WithSystemPrompt("You are a visual analysis assistant specialized in detailed image descriptions. If there is a person in the image describe what they are doing in step by step format."),
+	)
 }


### PR DESCRIPTION
This fixes some breaking changes in the API that I pushed last night. Primarily:

* utilization of the `logr` interface (which can support Zap loggers)
* the `agent.DefaultAgent` is now just `agent.Agent` (still unsure of the best naming in the API here but I think this makes the most sense)
* Uses the `agent-api/core/agent/bootstrap` package to bootstrap a new agent